### PR TITLE
Support miliseconds

### DIFF
--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -961,9 +961,10 @@ int main(int argc, char **argv)
 	/* actually do stuff */
 	rtlsdr_set_sample_rate(dev, (uint32_t)tunes[0].rate);
 	sine_table(tunes[0].bin_e);
-	next_tick = time(NULL) + interval_ms;
+	next_tick_ms = time_ms() + interval_ms;
 	if (exit_time) {
-		exit_time = time(NULL) + exit_time;}
+		exit_time = time_ms() + exit_time * 1000;
+	}
 	fft_buf = malloc(tunes[0].buf_len * sizeof(int16_t));
 	length = 1 << tunes[0].bin_e;
 	window_coefs = malloc(length * sizeof(int));
@@ -972,10 +973,11 @@ int main(int argc, char **argv)
 	}
 	while (!do_exit) {
 		scanner();
-		time_now = time(NULL);
-		if (time_now < next_tick) {
+		time_now_ms = time_ms();
+		if (time_now_ms < next_tick_ms) {
 			continue;}
 		// time, Hz low, Hz high, Hz step, samples, dbm, dbm, ...
+		time_now = time(NULL);
 		cal_time = localtime(&time_now);
 		strftime(t_str, 50, "%Y-%m-%d, %H:%M:%S", cal_time);
 		for (i=0; i<tune_count; i++) {
@@ -983,11 +985,10 @@ int main(int argc, char **argv)
 			csv_dbm(&tunes[i]);
 		}
 		fflush(file);
-		while (time(NULL) >= next_tick) {
-			next_tick += interval_ms;}
+		next_tick_ms = time_ms() + interval_ms;
 		if (single) {
 			do_exit = 1;}
-		if (exit_time && time(NULL) >= exit_time) {
+		if (exit_time && time_ms() >= exit_time) {
 			do_exit = 1;}
 	}
 

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -754,6 +754,12 @@ void csv_dbm(struct tuning_state *ts)
 	ts->samples = 0;
 }
 
+time_t time_ms() {
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	return now.tv_sec * 1000 + now.tv_usec / 1000;
+}
+
 int main(int argc, char **argv)
 {
 #ifndef _WIN32
@@ -775,7 +781,8 @@ int main(int argc, char **argv)
 	int enable_biastee = 0;
 	double crop = 0.0;
 	char *freq_optarg;
-	time_t next_tick;
+	time_t next_tick_ms;
+	time_t time_now_ms;
 	time_t time_now;
 	time_t exit_time = 0;
 	char t_str[50];

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -772,7 +772,7 @@ int main(int argc, char **argv)
 	int dev_index = 0;
 	int dev_given = 0;
 	int ppm_error = 0;
-	int interval = 10;
+	int interval_ms = 10000;
 	int fft_threads = 1;
 	int smoothing = 0;
 	int single = 0;
@@ -807,7 +807,7 @@ int main(int argc, char **argv)
 			crop = atofp(optarg);
 			break;
 		case 'i':
-			interval = (int)round(atoft(optarg));
+			interval_ms = (int) (atoft(optarg) * 1000);
 			break;
 		case 'e':
 			exit_time = (time_t)((int)round(atoft(optarg)));
@@ -889,10 +889,10 @@ int main(int argc, char **argv)
 		filename = argv[optind];
 	}
 
-	if (interval < 1) {
-		interval = 1;}
+	if (interval_ms < 1) {
+		interval_ms = 1;}
 
-	fprintf(stderr, "Reporting every %i seconds\n", interval);
+	fprintf(stderr, "Reporting every %i milliseconds\n", interval_ms);
 
 	if (!dev_given) {
 		dev_index = verbose_device_search("0");
@@ -961,7 +961,7 @@ int main(int argc, char **argv)
 	/* actually do stuff */
 	rtlsdr_set_sample_rate(dev, (uint32_t)tunes[0].rate);
 	sine_table(tunes[0].bin_e);
-	next_tick = time(NULL) + interval;
+	next_tick = time(NULL) + interval_ms;
 	if (exit_time) {
 		exit_time = time(NULL) + exit_time;}
 	fft_buf = malloc(tunes[0].buf_len * sizeof(int16_t));
@@ -984,7 +984,7 @@ int main(int argc, char **argv)
 		}
 		fflush(file);
 		while (time(NULL) >= next_tick) {
-			next_tick += interval;}
+			next_tick += interval_ms;}
 		if (single) {
 			do_exit = 1;}
 		if (exit_time && time(NULL) >= exit_time) {


### PR DESCRIPTION
It was not possible to use a `integration interval` smaller than one second. This PR allows the user to use fractional values to set the `integration` parameter. Example:
`./rtl_power -f 902.2M:902.6M:1k -w blackman-harris -g 32 -e 10 -i 0.1 power.csv`

It also works for minutes:
`./rtl_power -f 902.2M:902.6M:1k -w blackman-harris -g 32 -e 240 -i 0.5m power.csv`

And hours:
`./rtl_power -f 902.2M:902.6M:1k -w blackman-harris -g 32 -e 2h -i 0.3h power.csv`