### PR TITLE
Enable better UHF reception (>862MHz) on devices with FC0013 tuners

### DIFF
--- a/src/tuner_fc0013.c
+++ b/src/tuner_fc0013.c
@@ -248,11 +248,11 @@ int fc0013_set_params(void *dev, uint32_t freq, uint32_t bandwidth)
 		if (ret)
 			goto exit;
 
-		/* disable UHF & enable GPS */
+		/* enable UHF & disable GPS */
 		ret = fc0013_readreg(dev, 0x14, &tmp);
 		if (ret)
 			goto exit;
-		ret = fc0013_writereg(dev, 0x14, (tmp & 0x1f) | 0x20);
+		ret = fc0013_writereg(dev, 0x14, (tmp & 0x1f) | 0x40);
 		if (ret)
 			goto exit;
 	}


### PR DESCRIPTION
Proof of concept code. Not sure what this bit does, if it alters a filter or if it controls antenna input selection. But with this change reception of fm modulated audio on 863.8MHz was possible and sensor data reception on 868.8MHz was significantly better. So for all rtl-sdr dongles out there this type of change should be done.

Not tested is ADSB reception. There is a possibility that it is possible. Tests with a signal generator has not been done yet.