### PR TITLE
tuner_r82xx: fix short-write in r82xx_read

### DIFF
--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -330,8 +330,14 @@ static int r82xx_read(struct r82xx_priv *priv, uint8_t reg, uint8_t *val, int le
 	priv->buf[0] = reg;
 
 	rc = rtlsdr_i2c_write_fn(priv->rtl_dev, priv->cfg->i2c_addr, priv->buf, 1);
-	if (rc < 1)
-		return rc;
+
+	if (rc != 1) {
+		fprintf(stderr, "%s: i2c wr failed=%d reg=%02x len=%d\n",
+			   __FUNCTION__, rc, reg, 1);
+		if (rc < 0)
+			return rc;
+		return -1;
+	}
 
 	rc = rtlsdr_i2c_read_fn(priv->rtl_dev, priv->cfg->i2c_addr, p, len);
 


### PR DESCRIPTION
In r82xx_read, there is a 1-byte I2C write followed by the I2C read.  If
this I2C write fails, r82xx_read correctly bails out but may return 0.
Callers that check whether (rc < 0) will assume that the buffer was written
when it has not been, e.g. in r82xx_set_tv_standard where

	priv->fil_cal_code = data[4] & 0x0f;

consumes a garbage value for data[4].

This change resolves that issue by copying the error path from r82xx_write.