### PR TITLE
librtlsdr: Allow device specification with an USB path

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -50,6 +50,31 @@ RTLSDR_API int rtlsdr_get_device_usb_strings(uint32_t index,
 					     char *serial);
 
 /*!
+ * Get device index by USB path string.
+ *
+ * The path string has the format "bus-port.port..."
+ * (i.e. the bus number, followed by a hyphen, then
+ * followed by the port numbers separated by dots).
+ *
+ * \param path path string of the device
+ * \return device index of the device with the given path
+ * \return -1 if no matching device was found.
+ */
+RTLSDR_API int rtlsdr_get_index_by_path(const char *path);
+
+/*!
+ * Get the USB path.
+ *
+ * NOTE: The buffer should provide space for at least 32 bytes.
+ *
+ * \param index the device index
+ * \param buf buffer where the path will be written
+ * \param len size of the buffer
+ * \return 0 on success
+ */
+RTLSDR_API int rtlsdr_get_device_path(uint32_t index, char *buf, size_t len);
+
+/*!
  * Get device index by USB serial string descriptor.
  *
  * \param serial serial string of the device

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -268,6 +268,16 @@ int verbose_device_search(char *s)
 			device, rtlsdr_get_device_name((uint32_t)device));
 		return device;
 	}
+	/* does string match a path */
+	if (s2[0] == '-') {
+		i = rtlsdr_get_index_by_path(s);
+		if (i >= 0) {
+			device = i;
+			fprintf(stderr, "Using device %d: %s\n",
+				device, rtlsdr_get_device_name((uint32_t)device));
+			return device;
+		}
+	}
 	/* does string exact match a serial */
 	for (i = 0; i < device_count; i++) {
 		rtlsdr_get_device_usb_strings(i, vendor, product, serial);


### PR DESCRIPTION
I tried to send this patch to the mailing list, but my mail is waiting for the moderator's approval for a month now.
Therefore I publish it here, too.

I'm using a Raspberry with two similar devices but different antennas. Specifying the device via index didn't work, because the enumeration of devices changed from time to time. Therefore I implemented functions to give a USB path instead. This path looks the same as the Linux kernel uses (eg. "4-1.2") and contains the USB bus and port numbers.