### PR TITLE
force wait state after lib_cancel_transfer to avoid crash 

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1930,6 +1930,9 @@ int rtlsdr_read_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx,
 					/* handle events after canceling
 					 * to allow transfer status to
 					 * propagate */
+#ifdef _WIN32
+					Sleep(1);
+#endif
 					libusb_handle_events_timeout_completed(dev->ctx,
 									       &zerotv, NULL);
 					if (r < 0)


### PR DESCRIPTION
Good day!

I was struggling with an occasional crash of the rtl-sdr tools on windows when closing the device after pressing CTRL-C. Both with the versions as provided with VCPKG and when directly compiling the latest version in MSVC (with latest of libusb). It is a bit difficult to spot a crash at close as usually is silent but you can see it running it from MSVC (see below) or in a debugger.  It does not happen always but frequent enough.

After investigation of the libusb logs and experimentation I think this crash can be avoided by 1) defining zerotv in ```rtlsdr_read_async```  as 1 ms instead of zero (see https://github.com/libusb/libusb/issues/1043)  or 2) include a short call to Sleep to allow async operations to finish.  Please find here a pull request for the latter for your consideration.

Thanks for your great work on the rtlsdr library and kind regards.

```
Found 1 device(s):
  0:  Realtek, RTL2838UHIDIR, SN: 7

Using device 0: Generic RTL2832U OEM
Found Rafael Micro R820T tuner
[R82XX] PLL not locked!
Sampling at 1536000 S/s.
Tuned to 162000000 Hz.
Tuner gain set to automatic.
Reading samples in async mode...
Signal caught, exiting!

User cancel, exiting...

(process 3988) exited with code -1073741819.
```
