### PR TITLE
rtl_adsb.c: Fix spelling of "verbose" in --help

### DIFF
--- a/debian/rtl_adsb.1
+++ b/debian/rtl_adsb.1
@@ -30,7 +30,7 @@ data decoded from that signal.
 .B  rtl_adsb [-R] [-g gain] [-p ppm] [output file]
 .SH OPTIONS
 .IP "-d device_index (default: 0)"
-.IP "-V verbove output (default: off)"
+.IP "-V verbose output (default: off)"
 .IP "-S show short frames (default: off)"
 .IP "-Q quality (0: no sanity checks, 0.5: half bit, 1: one bit (default), 2: two bits)"
 .IP "-e allowed_errors (default: 5)"

--- a/src/rtl_adsb.c
+++ b/src/rtl_adsb.c
@@ -90,7 +90,7 @@ void usage(void)
 		"rtl_adsb, a simple ADS-B decoder\n\n"
 		"Use:\trtl_adsb [-R] [-g gain] [-p ppm] [output file]\n"
 		"\t[-d device_index (default: 0)]\n"
-		"\t[-V verbove output (default: off)]\n"
+		"\t[-V verbose output (default: off)]\n"
 		"\t[-S show short frames (default: off)]\n"
 		"\t[-Q quality (0: no sanity checks, 0.5: half bit, 1: one bit (default), 2: two bits)]\n"
 		"\t[-e allowed_errors (default: 5)]\n"


### PR DESCRIPTION
Figured I'd just fix it while I'm passing through. Thanks!