### PR TITLE
Fix small typo in rtl_sdr man page

### DIFF
--- a/debian/rtl_sdr.1
+++ b/debian/rtl_sdr.1
@@ -26,7 +26,7 @@ This program captures information from a band of frequencies
 and outputs the data in a form useful to other software radio
 programs.
 .SH SYNOPSIS
-.B  rtl_adsb [-f freq] [OPTIONS] [output file]
+.B  rtl_sdr [-f freq] [OPTIONS] [output file]
 .SH OPTIONS
 .IP "-f frequency_to_tune_to [Hz]"
 .IP "-s samplerate (default: 2048000 Hz)"


### PR DESCRIPTION
Probably a 5 year old copy-paste error